### PR TITLE
prevent duplicate ligand atoms

### DIFF
--- a/surface_cont_lig.py
+++ b/surface_cont_lig.py
@@ -32,7 +32,8 @@ def read_residues(pdb_file, chains, ligand):
                 atom_name = line[12:16].strip()
                 atom_number = re.findall('[+-]?\d+',line[6:12])
                 string = str(atom_number[0]) + atom_name
-                list_atoms.append(string)
+                if string not in list_atoms:
+                    list_atoms.append(string)
     atoms_numbers = []
     for k in range(len(chains)):
         atoms_numbers.append([])


### PR DESCRIPTION
prevent duplicate ligand atoms by checking if line exists before appending